### PR TITLE
Implement basic world memory and dungeon systems

### DIFF
--- a/Assets/Scenes/MyrrhfenVillage.unity
+++ b/Assets/Scenes/MyrrhfenVillage.unity
@@ -1,0 +1,22 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &100000
+GameObject:
+  m_Name: MyrrhfenVillage
+  m_IsActive: 1
+--- !u!224 &100001
+MonoBehaviour:
+  m_GameObject: {fileID: 100000}
+  m_Script: {fileID: 11500000, guid: 0000000000000000e000000000000000, type: 3}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_ScriptAsset: {fileID: 0}
+  m_Name: MyrrhfenScenePlaceholder
+  m_EditorClassIdentifier: 
+  m_SpawnPoint: {x:0, y:0, z:0}
+  m_NPCSpawner: {x:10, y:0, z:0}
+  m_DungeonPortal: {x:20, y:0, z:0}
+# This is a placeholder Unity scene file. Create a real scene in Unity with
+# a Player spawn point, an NPC spawner and a portal to the dungeon.

--- a/Assets/Scripts/AI/AIMemory.cs
+++ b/Assets/Scripts/AI/AIMemory.cs
@@ -2,14 +2,14 @@ using UnityEngine;
 using System.Collections.Generic;
 
 /// <summary>
-/// Stores key events and decisions so AI characters can remember the player's
-/// actions over time.
+/// Base class for AI memory. Stores key events and decisions so AI characters
+/// can remember the player's actions over time.
 /// </summary>
 public class AIMemory : MonoBehaviour
 {
-    private readonly List<string> memoryLog = new List<string>();
+    protected readonly List<string> memoryLog = new List<string>();
 
-    public void Remember(string entry)
+    protected void Remember(string entry)
     {
         memoryLog.Add(entry);
         if (memoryLog.Count > 100)

--- a/Assets/Scripts/AI/CompanionMemory.cs
+++ b/Assets/Scripts/AI/CompanionMemory.cs
@@ -1,0 +1,43 @@
+using UnityEngine;
+using System.Collections.Generic;
+
+/// <summary>
+/// Tracks events shared with the player and emotional state for a companion.
+/// </summary>
+public class CompanionMemory : AIMemory
+{
+    [System.Serializable]
+    public class EventEntry
+    {
+        public string description;
+        public float timestamp;
+    }
+
+    public List<EventEntry> sharedEvents = new List<EventEntry>();
+    public int bondLevel = 50; // 0-100
+    public Dictionary<string, float> disposition = new Dictionary<string, float>
+    {
+        {"loyal", 0f},
+        {"cautious", 0f},
+        {"rebellious", 0f},
+        {"curious", 0f}
+    };
+
+    public void AddEvent(string desc)
+    {
+        sharedEvents.Add(new EventEntry { description = desc, timestamp = Time.time });
+        Remember(desc);
+    }
+
+    public void AdjustBond(int amount)
+    {
+        bondLevel = Mathf.Clamp(bondLevel + amount, 0, 100);
+    }
+
+    public void AdjustDisposition(string trait, float amount)
+    {
+        if (!disposition.ContainsKey(trait))
+            disposition[trait] = 0f;
+        disposition[trait] += amount;
+    }
+}

--- a/Assets/Scripts/AI/NPCMemory.cs
+++ b/Assets/Scripts/AI/NPCMemory.cs
@@ -1,0 +1,28 @@
+using UnityEngine;
+using System;
+
+/// <summary>
+/// Memory data for NPCs persisting simple interaction state.
+/// </summary>
+public class NPCMemory : AIMemory
+{
+    public DateTime lastInteraction;
+    public int reputation;
+    public string lastDialogueOption;
+    public string previousDialogueOption;
+    public readonly System.Collections.Generic.HashSet<string> flags = new System.Collections.Generic.HashSet<string>();
+
+    public void RecordInteraction(string dialogueOption, int reputationDelta)
+    {
+        previousDialogueOption = lastDialogueOption;
+        lastDialogueOption = dialogueOption;
+        reputation += reputationDelta;
+        lastInteraction = DateTime.UtcNow;
+        Remember($"Spoke: {dialogueOption}");
+    }
+
+    public void SetFlag(string flag)
+    {
+        flags.Add(flag);
+    }
+}

--- a/Assets/Scripts/Characters/CompanionAI.cs
+++ b/Assets/Scripts/Characters/CompanionAI.cs
@@ -10,12 +10,15 @@ public class CompanionAI : MonoBehaviour
 {
     public Transform player;
     public float followDistance = 2f;
+    public CompanionMemory memory;
 
     private UnityEngine.AI.NavMeshAgent agent;
 
     private void Awake()
     {
         agent = GetComponent<UnityEngine.AI.NavMeshAgent>();
+        if (memory == null)
+            memory = GetComponent<CompanionMemory>();
     }
 
     private void Update()
@@ -31,5 +34,20 @@ public class CompanionAI : MonoBehaviour
         {
             agent.ResetPath();
         }
+    }
+
+    public void ReactToEvent(string eventType)
+    {
+        memory.AddEvent(eventType);
+    }
+
+    public void CommentOnQuest(string questId)
+    {
+        Debug.Log($"Companion comments on quest {questId}");
+    }
+
+    public void AdjustDisposition(string trait, float amount)
+    {
+        memory.AdjustDisposition(trait, amount);
     }
 }

--- a/Assets/Scripts/Characters/PersistentNPC.cs
+++ b/Assets/Scripts/Characters/PersistentNPC.cs
@@ -1,0 +1,35 @@
+using UnityEngine;
+
+/// <summary>
+/// Provides a unique identifier for NPCs and automatically loads/saves their
+/// memory to disk.
+/// </summary>
+[RequireComponent(typeof(NPCMemory))]
+public class PersistentNPC : MonoBehaviour
+{
+    public string npcId = System.Guid.NewGuid().ToString();
+    private NPCMemory memory;
+
+    private string SavePath => System.IO.Path.Combine(Application.persistentDataPath, $"npc_{npcId}.json");
+
+    private void Awake()
+    {
+        memory = GetComponent<NPCMemory>();
+        LoadMemory();
+    }
+
+    public void SaveMemory()
+    {
+        var json = JsonUtility.ToJson(memory, true);
+        System.IO.File.WriteAllText(SavePath, json);
+    }
+
+    private void LoadMemory()
+    {
+        if (System.IO.File.Exists(SavePath))
+        {
+            var json = System.IO.File.ReadAllText(SavePath);
+            JsonUtility.FromJsonOverwrite(json, memory);
+        }
+    }
+}

--- a/Assets/Scripts/Core/SceneLoader.cs
+++ b/Assets/Scripts/Core/SceneLoader.cs
@@ -1,5 +1,16 @@
 using UnityEngine;
 using UnityEngine.SceneManagement;
+using System.Collections;
+
+/// <summary>
+/// Information about a procedural scene request.
+/// </summary>
+public struct ProceduralSceneRequest
+{
+    public string zoneName;
+    public int seed;
+    public int size;
+}
 
 /// <summary>
 /// Responsible for loading and unloading Unity scenes. Use this for transitioning
@@ -7,6 +18,8 @@ using UnityEngine.SceneManagement;
 /// </summary>
 public class SceneLoader : MonoBehaviour
 {
+    public WorldMemory worldMemory;
+
     /// <summary>
     /// Load a scene by name. Can be expanded to include loading screens or async
     /// operations.
@@ -32,5 +45,46 @@ public class SceneLoader : MonoBehaviour
             yield return null;
         }
         onComplete?.Invoke();
+    }
+
+    /// <summary>
+    /// Load a procedural dungeon. If the zone was generated previously, the same
+    /// seed is used. Otherwise a new entry is created in WorldMemory.
+    /// </summary>
+    public void LoadProceduralDungeon(ProceduralSceneRequest request)
+    {
+        StartCoroutine(LoadDungeonRoutine(request));
+    }
+
+    private System.Collections.IEnumerator LoadDungeonRoutine(ProceduralSceneRequest request)
+    {
+        // Load an empty scene to host the dungeon
+        var op = SceneManager.LoadSceneAsync("EmptyDungeon");
+        while (!op.isDone)
+            yield return null;
+
+        if (worldMemory == null)
+            worldMemory = FindObjectOfType<WorldMemory>();
+
+        if (worldMemory != null)
+        {
+            var info = worldMemory.GetZone(request.zoneName);
+            if (info == null)
+            {
+                worldMemory.RegisterZone(request.zoneName, request.seed, Vector3.zero);
+                worldMemory.Save();
+            }
+            else
+            {
+                request.seed = info.seed;
+            }
+        }
+
+        // Spawn a generator in the scene
+        var generatorObj = new GameObject("DungeonGenerator");
+        var generator = generatorObj.AddComponent<DungeonGenerator>();
+        generator.seed = request.seed;
+        generator.size = request.size;
+        generator.Generate();
     }
 }

--- a/Assets/Scripts/Core/WorldMemory.cs
+++ b/Assets/Scripts/Core/WorldMemory.cs
@@ -1,0 +1,74 @@
+using UnityEngine;
+using System.IO;
+using System.Collections.Generic;
+
+/// <summary>
+/// Keeps track of procedural zones that have been generated. Each entry stores
+/// a seed, an entrance position and whether the zone was cleared. Data is
+/// persisted to JSON so the world remains consistent across play sessions.
+/// </summary>
+public class WorldMemory : MonoBehaviour
+{
+    [System.Serializable]
+    public class ZoneInfo
+    {
+        public string zoneName;
+        public int seed;
+        public Vector3 entrance;
+        public bool cleared;
+    }
+
+    [SerializeField]
+    private List<ZoneInfo> zones = new List<ZoneInfo>();
+
+    private string SavePath => Path.Combine(Application.persistentDataPath, "worldmemory.json");
+
+    public ZoneInfo GetZone(string name)
+    {
+        return zones.Find(z => z.zoneName == name);
+    }
+
+    public void RegisterZone(string name, int seed, Vector3 entrance)
+    {
+        var zone = GetZone(name);
+        if (zone == null)
+        {
+            zone = new ZoneInfo { zoneName = name, seed = seed, entrance = entrance, cleared = false };
+            zones.Add(zone);
+        }
+        else
+        {
+            zone.seed = seed;
+            zone.entrance = entrance;
+        }
+    }
+
+    public void MarkCleared(string name)
+    {
+        var zone = GetZone(name);
+        if (zone != null)
+            zone.cleared = true;
+    }
+
+    public void Save()
+    {
+        var json = JsonUtility.ToJson(new ZoneCollection { zones = zones }, true);
+        File.WriteAllText(SavePath, json);
+    }
+
+    public void Load()
+    {
+        if (File.Exists(SavePath))
+        {
+            var json = File.ReadAllText(SavePath);
+            var data = JsonUtility.FromJson<ZoneCollection>(json);
+            zones = data.zones ?? new List<ZoneInfo>();
+        }
+    }
+
+    [System.Serializable]
+    private class ZoneCollection
+    {
+        public List<ZoneInfo> zones;
+    }
+}

--- a/Assets/Scripts/Dialogue/DialogueSystem.cs
+++ b/Assets/Scripts/Dialogue/DialogueSystem.cs
@@ -5,9 +5,34 @@ using UnityEngine;
 /// conversational state. This is where AI-generated dialogue can be plugged in.
 /// </summary>
 public class DialogueSystem : MonoBehaviour
-{
+{ 
     public void Say(string speaker, string line)
     {
         Debug.Log($"{speaker}: {line}");
+    }
+
+    /// <summary>
+    /// Say a line influenced by memory state of the speaker.
+    /// </summary>
+    public void Say(string speaker, string line, AIMemory memory)
+    {
+        string prefix = string.Empty;
+
+        if (memory is CompanionMemory cm)
+        {
+            if (cm.disposition.TryGetValue("rebellious", out float reb) && reb > 5f)
+                prefix = "[Rebellious] ";
+            else if (cm.disposition.TryGetValue("loyal", out float loy) && loy > 5f)
+                prefix = "[Loyal] ";
+        }
+        else if (memory is NPCMemory npc)
+        {
+            if (npc.reputation < -10)
+                prefix = "[Hostile] ";
+            else if (npc.reputation > 10)
+                prefix = "[Friendly] ";
+        }
+
+        Debug.Log($"{speaker}: {prefix}{line}");
     }
 }

--- a/Assets/Scripts/WorldGen/DungeonGenerator.cs
+++ b/Assets/Scripts/WorldGen/DungeonGenerator.cs
@@ -1,19 +1,98 @@
 using UnityEngine;
+using System.Collections.Generic;
 
 /// <summary>
-/// Handles procedural generation of dungeon layouts. Currently this only creates
-/// placeholder geometry but can be expanded with rooms, corridors and theming.
+/// Generates a simple procedural dungeon using a seeded random walk. Rooms are
+/// connected with corridors and a goal room is spawned at the end.
 /// </summary>
 public class DungeonGenerator : MonoBehaviour
 {
     public GameObject roomPrefab;
-    public int roomCount = 5;
+    public GameObject corridorPrefab;
+    public GameObject enemyPlaceholder;
+    public GameObject lootPlaceholder;
+    public GameObject portalPrefab;
 
+    public int seed = 0;
+    public int size = 5;
+
+    private readonly List<Vector3> roomPositions = new List<Vector3>();
+
+    /// <summary>
+    /// Generates the dungeon layout. If seed is zero a random seed is chosen.
+    /// </summary>
     public void Generate()
     {
-        for (int i = 0; i < roomCount; i++)
+        if (seed == 0)
+            seed = System.DateTime.Now.Millisecond;
+
+        Random.InitState(seed);
+        int roomCount = Mathf.Clamp(size, 3, 7);
+        Vector3 currentPos = Vector3.zero;
+        roomPositions.Add(currentPos);
+
+        // Random walk to place rooms
+        for (int i = 1; i < roomCount; i++)
         {
-            Instantiate(roomPrefab, transform.position + Vector3.right * i * 5, Quaternion.identity, transform);
+            Vector3 dir = GetRandomDirection();
+            currentPos += dir * 10f;
+            roomPositions.Add(currentPos);
+        }
+
+        // Instantiate rooms and corridors
+        for (int i = 0; i < roomPositions.Count; i++)
+        {
+            var room = Instantiate(roomPrefab, roomPositions[i], Quaternion.identity, transform);
+            room.name = $"Room_{i}";
+
+            SpawnContents(room.transform);
+
+            if (i > 0)
+            {
+                Vector3 prev = roomPositions[i - 1];
+                CreateCorridor(prev, roomPositions[i]);
+            }
+        }
+
+        // Goal room object/boss
+        var goal = new GameObject("GoalObject");
+        goal.transform.position = roomPositions[roomPositions.Count - 1];
+        goal.transform.SetParent(transform);
+
+        // Portal back to village at entrance
+        if (portalPrefab != null)
+        {
+            Instantiate(portalPrefab, roomPositions[0] + Vector3.back * 2, Quaternion.identity, transform);
+        }
+    }
+
+    private void SpawnContents(Transform room)
+    {
+        if (enemyPlaceholder != null && Random.value > 0.5f)
+            Instantiate(enemyPlaceholder, room.position + Vector3.right * 2, Quaternion.identity, room);
+        if (lootPlaceholder != null && Random.value > 0.5f)
+            Instantiate(lootPlaceholder, room.position + Vector3.left * 2, Quaternion.identity, room);
+    }
+
+    private void CreateCorridor(Vector3 from, Vector3 to)
+    {
+        if (corridorPrefab == null) return;
+        Vector3 mid = (from + to) / 2f;
+        Quaternion rot = Quaternion.LookRotation(to - from);
+        float length = Vector3.Distance(from, to);
+        var corridor = Instantiate(corridorPrefab, mid, rot, transform);
+        corridor.transform.localScale = new Vector3(1, 1, length);
+    }
+
+    private Vector3 GetRandomDirection()
+    {
+        int r = Random.Range(0, 4);
+        switch (r)
+        {
+            case 0: return Vector3.forward;
+            case 1: return Vector3.back;
+            case 2: return Vector3.left;
+            default: return Vector3.right;
         }
     }
 }


### PR DESCRIPTION
## Summary
- add placeholder MyrrhfenVillage scene
- extend SceneLoader with procedural dungeon loading and world memory
- implement WorldMemory for saving generated zones
- overhaul DungeonGenerator with seeded random walk generation
- split AIMemory into subclasses with NPC and companion memories
- add PersistentNPC component
- expand CompanionAI with memory driven behaviour
- update dialogue to respect NPC/companion dispositions

## Testing
- `python -m py_compile $(git ls-files '*.py')` *(fails: the following arguments are required: filenames)*

------
https://chatgpt.com/codex/tasks/task_e_6850f2e799e483309aea335f676842f7