### PR TITLE
Add initial region data system

### DIFF
--- a/Assets/Scripts/WorldData/RegionData.cs
+++ b/Assets/Scripts/WorldData/RegionData.cs
@@ -1,0 +1,15 @@
+using UnityEngine;
+
+/// <summary>
+/// Describes a world region and its basic properties.
+/// </summary>
+[System.Serializable]
+public class RegionData
+{
+    public string name;
+    [TextArea]
+    public string description;
+    public string deity;
+    public int minLevel;
+    public int maxLevel;
+}

--- a/Assets/Scripts/WorldData/RegionManager.cs
+++ b/Assets/Scripts/WorldData/RegionManager.cs
@@ -1,0 +1,50 @@
+using UnityEngine;
+using System.IO;
+using System.Collections.Generic;
+
+/// <summary>
+/// Loads region data from a JSON file and provides access to regions by name.
+/// The JSON file should be placed under StreamingAssets/regions.json.
+/// </summary>
+public class RegionManager : MonoBehaviour
+{
+    public string regionsFile = "regions.json";
+    public List<RegionData> regions = new List<RegionData>();
+
+    private void Awake()
+    {
+        LoadRegions();
+    }
+
+    /// <summary>
+    /// Loads region definitions from StreamingAssets.
+    /// </summary>
+    public void LoadRegions()
+    {
+        string path = Path.Combine(Application.streamingAssetsPath, regionsFile);
+        if (!File.Exists(path))
+        {
+            Debug.LogWarning($"Region file not found at {path}");
+            return;
+        }
+
+        string json = File.ReadAllText(path);
+        var wrapper = JsonUtility.FromJson<RegionCollection>(json);
+        if (wrapper != null && wrapper.regions != null)
+            regions = wrapper.regions;
+    }
+
+    /// <summary>
+    /// Get region data by name.
+    /// </summary>
+    public RegionData GetRegion(string name)
+    {
+        return regions.Find(r => r.name == name);
+    }
+
+    [System.Serializable]
+    private class RegionCollection
+    {
+        public List<RegionData> regions;
+    }
+}

--- a/Assets/StreamingAssets/regions.json
+++ b/Assets/StreamingAssets/regions.json
@@ -1,0 +1,46 @@
+{
+  "regions": [
+    {
+      "name": "Aurelia",
+      "description": "Golden fields, temples, and capital of divine influence.",
+      "deity": "Solinar",
+      "minLevel": 1,
+      "maxLevel": 10
+    },
+    {
+      "name": "Verdancia",
+      "description": "Ancient forestland filled with fae ruins and druidic culture.",
+      "deity": "Myrielle",
+      "minLevel": 1,
+      "maxLevel": 10
+    },
+    {
+      "name": "Durndara",
+      "description": "Mountainous realm of dwarven forges and volcanic terrain.",
+      "deity": "Durak Thorne",
+      "minLevel": 10,
+      "maxLevel": 20
+    },
+    {
+      "name": "Selenora",
+      "description": "Moonlit mystic region with floating forests and astral temples.",
+      "deity": "Velalune",
+      "minLevel": 10,
+      "maxLevel": 20
+    },
+    {
+      "name": "Tharnor",
+      "description": "War-torn deserts and necrotic battlefields swept by sandstorms.",
+      "deity": "Vakhor",
+      "minLevel": 20,
+      "maxLevel": 30
+    },
+    {
+      "name": "Vokaria",
+      "description": "Ocean-drowned ruins ruled by storm altars and serpent clans.",
+      "deity": "Thal’shara",
+      "minLevel": 20,
+      "maxLevel": 30
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -17,6 +17,10 @@ WhippyRealms is a fantasy RPG project built in Unity. It aims to create a dynami
 3. The main scripts live in `Assets/Scripts`. Attach them to GameObjects as needed.
 4. To run the sample scene, create a new scene and add a `GameManager` with `SceneLoader` and `SaveSystem` components.
 
+## Region Data
+
+World regions are defined in `Assets/StreamingAssets/regions.json`. The new `RegionManager` script loads this file at runtime so you can expand the map without modifying code. Each entry describes a region name, controlling deity and recommended level range.
+
 ## Python Tools
 
 Some AI integrations can be prototyped with Python. Install dependencies using:


### PR DESCRIPTION
## Summary
- create JSON region definitions under `StreamingAssets`
- add `RegionData` class to represent a region
- add `RegionManager` that loads regions at runtime
- document how to edit `regions.json`

## Testing
- `python -m pip install openai`
- `python -m pip install -r requirements.txt` *(fails: `coqui-ai` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685749bd46808330afad29edc8036bfe