### PR TITLE
Implement region terrain and spawner systems

### DIFF
--- a/Assets/Scripts/WorldData/RegionData.cs
+++ b/Assets/Scripts/WorldData/RegionData.cs
@@ -12,4 +12,10 @@ public class RegionData
     public string deity;
     public int minLevel;
     public int maxLevel;
+    public string elevationType;
+    public string vegetationType;
+    public string climateType;
+    public string[] terrainFeatures;
+    public string tag;
+    public int levelZone;
 }

--- a/Assets/Scripts/WorldGen/BiomeCreatureSpawner.cs
+++ b/Assets/Scripts/WorldGen/BiomeCreatureSpawner.cs
@@ -1,0 +1,57 @@
+using UnityEngine;
+using System.Collections.Generic;
+
+/// <summary>
+/// Spawns creatures based on region difficulty and biome settings.
+/// Common creatures spawn regularly while elite or mythic creatures have
+/// conditional spawn logic using the region metadata.
+/// </summary>
+public class BiomeCreatureSpawner : MonoBehaviour
+{
+    public RegionData region;
+    public List<GameObject> commonCreatures = new List<GameObject>();
+    public List<GameObject> eliteCreatures = new List<GameObject>();
+    public List<GameObject> mythicCreatures = new List<GameObject>();
+
+    public float spawnRadius = 20f;
+    public float spawnInterval = 10f;
+    private float timer;
+
+    private void Update()
+    {
+        if (region == null)
+            return;
+
+        timer += Time.deltaTime;
+        if (timer >= spawnInterval)
+        {
+            SpawnCreature();
+            timer = 0f;
+        }
+    }
+
+    private void SpawnCreature()
+    {
+        GameObject prefab = ChooseCreature();
+        if (prefab == null)
+            return;
+
+        Vector3 pos = transform.position + new Vector3(Random.Range(-spawnRadius, spawnRadius), 0f,
+                                                        Random.Range(-spawnRadius, spawnRadius));
+        Instantiate(prefab, pos, Quaternion.identity, transform);
+    }
+
+    private GameObject ChooseCreature()
+    {
+        if (region.levelZone >= 25 && mythicCreatures.Count > 0 && Random.value > 0.95f)
+            return mythicCreatures[Random.Range(0, mythicCreatures.Count)];
+
+        if (region.levelZone >= 25 && eliteCreatures.Count > 0)
+            return eliteCreatures[Random.Range(0, eliteCreatures.Count)];
+
+        if (commonCreatures.Count > 0)
+            return commonCreatures[Random.Range(0, commonCreatures.Count)];
+
+        return null;
+    }
+}

--- a/Assets/Scripts/WorldGen/EnvironmentSeeder.cs
+++ b/Assets/Scripts/WorldGen/EnvironmentSeeder.cs
@@ -1,0 +1,72 @@
+using UnityEngine;
+using System.Collections.Generic;
+
+/// <summary>
+/// Places environment prefabs such as cities, shrines and ruins based on region
+/// data. Placement can use predefined anchor points or simple Perlin noise
+/// distribution. Objects are parented under this component for easy cleanup when
+/// the region unloads.
+/// </summary>
+public class EnvironmentSeeder : MonoBehaviour
+{
+    public RegionManager regionManager;
+    public string regionName;
+
+    [Header("Prefabs")]
+    public List<GameObject> cityPrefabs = new List<GameObject>();
+    public List<GameObject> shrinePrefabs = new List<GameObject>();
+    public List<GameObject> wonderPrefabs = new List<GameObject>();
+    public List<GameObject> ruinPrefabs = new List<GameObject>();
+
+    [Tooltip("Optional anchor points inside the terrain where prefabs may spawn.")]
+    public List<Transform> anchors = new List<Transform>();
+
+    public float perlinScale = 10f;
+
+    private void Start()
+    {
+        if (regionManager == null)
+            regionManager = FindObjectOfType<RegionManager>();
+        SeedRegion(regionName);
+    }
+
+    /// <summary>
+    /// Spawns prefabs appropriate for the region at anchor points or
+    /// procedurally generated positions.
+    /// </summary>
+    public void SeedRegion(string name)
+    {
+        if (regionManager == null || string.IsNullOrEmpty(name))
+            return;
+
+        var region = regionManager.GetRegion(name);
+        if (region == null)
+            return;
+
+        SpawnSet(cityPrefabs, 1);
+        SpawnSet(shrinePrefabs, 2);
+        SpawnSet(wonderPrefabs, 3);
+        SpawnSet(ruinPrefabs, 4);
+    }
+
+    private void SpawnSet(List<GameObject> prefabs, int seedOffset)
+    {
+        if (prefabs == null || prefabs.Count == 0)
+            return;
+
+        int count = anchors.Count > 0 ? anchors.Count : 3;
+        for (int i = 0; i < count; i++)
+        {
+            Vector3 pos = anchors.Count > i ? anchors[i].position : GetProceduralPosition(i + seedOffset);
+            var prefab = prefabs[Random.Range(0, prefabs.Count)];
+            Instantiate(prefab, pos, Quaternion.identity, transform);
+        }
+    }
+
+    private Vector3 GetProceduralPosition(int seed)
+    {
+        float x = Mathf.PerlinNoise(seed, 0f) * 50f - 25f;
+        float z = Mathf.PerlinNoise(0f, seed) * 50f - 25f;
+        return transform.position + new Vector3(x, 0f, z);
+    }
+}

--- a/Assets/Scripts/WorldGen/RegionTerrainManager.cs
+++ b/Assets/Scripts/WorldGen/RegionTerrainManager.cs
@@ -1,0 +1,121 @@
+using UnityEngine;
+
+/// <summary>
+/// Generates and configures a Unity Terrain using data loaded from RegionManager.
+/// Terrain elevation, textures and environment effects are chosen based on the
+/// region JSON metadata such as elevationType, vegetationType and climateType.
+/// </summary>
+[RequireComponent(typeof(Terrain))]
+public class RegionTerrainManager : MonoBehaviour
+{
+    public RegionManager regionManager;
+    public string regionName;
+    public ParticleSystem fogParticles;
+    public ParticleSystem rainParticles;
+    public ParticleSystem ashParticles;
+
+    private Terrain terrain;
+
+    private void Awake()
+    {
+        terrain = GetComponent<Terrain>();
+        if (regionManager == null)
+            regionManager = FindObjectOfType<RegionManager>();
+    }
+
+    private void Start()
+    {
+        if (!string.IsNullOrEmpty(regionName))
+            ApplyRegion(regionName);
+    }
+
+    /// <summary>
+    /// Apply terrain generation settings for the given region.
+    /// </summary>
+    public void ApplyRegion(string name)
+    {
+        if (terrain == null || regionManager == null)
+            return;
+
+        var region = regionManager.GetRegion(name);
+        if (region == null)
+        {
+            Debug.LogWarning($"Region {name} not found");
+            return;
+        }
+
+        GenerateHeights(region);
+        PaintTerrain(region);
+        SpawnWeather(region);
+    }
+
+    private void GenerateHeights(RegionData region)
+    {
+        var data = terrain.terrainData;
+        int width = data.heightmapResolution;
+        int height = data.heightmapResolution;
+        float[,] heights = new float[width, height];
+
+        float scale = 5f;
+        float amp = 0.1f;
+        if (region.elevationType == "mountains") amp = 0.3f;
+        else if (region.elevationType == "plains") amp = 0.05f;
+        else if (region.elevationType == "desert") amp = 0.08f;
+
+        for (int x = 0; x < width; x++)
+        {
+            for (int y = 0; y < height; y++)
+            {
+                float nx = (float)x / width * scale;
+                float ny = (float)y / height * scale;
+                heights[y, x] = Mathf.PerlinNoise(nx, ny) * amp;
+            }
+        }
+        data.SetHeights(0, 0, heights);
+    }
+
+    private void PaintTerrain(RegionData region)
+    {
+        // Example texture painting using the first alphamap layer indices.
+        // A real implementation would map textures to indices dynamically.
+        var data = terrain.terrainData;
+        int w = data.alphamapWidth;
+        int h = data.alphamapHeight;
+        float[,,] maps = new float[w, h, data.alphamapLayers];
+
+        int textureIndex = 0; // default grass
+        if (region.climateType == "arid")
+            textureIndex = 1; // sand
+        else if (region.climateType == "cold")
+            textureIndex = 2; // snow
+        else if (region.climateType == "lava")
+            textureIndex = 3; // lava rock
+
+        for (int y = 0; y < h; y++)
+        {
+            for (int x = 0; x < w; x++)
+            {
+                for (int i = 0; i < data.alphamapLayers; i++)
+                    maps[x, y, i] = (i == textureIndex) ? 1f : 0f;
+            }
+        }
+        data.SetAlphamaps(0, 0, maps);
+    }
+
+    private void SpawnWeather(RegionData region)
+    {
+        if (fogParticles != null)
+            fogParticles.gameObject.SetActive(false);
+        if (rainParticles != null)
+            rainParticles.gameObject.SetActive(false);
+        if (ashParticles != null)
+            ashParticles.gameObject.SetActive(false);
+
+        if (region.climateType == "humid" && rainParticles != null)
+            rainParticles.gameObject.SetActive(true);
+        else if (region.climateType == "arid" && fogParticles != null)
+            fogParticles.gameObject.SetActive(true);
+        else if (region.climateType == "lava" && ashParticles != null)
+            ashParticles.gameObject.SetActive(true);
+    }
+}

--- a/Assets/StreamingAssets/regions.json
+++ b/Assets/StreamingAssets/regions.json
@@ -5,42 +5,78 @@
       "description": "Golden fields, temples, and capital of divine influence.",
       "deity": "Solinar",
       "minLevel": 1,
-      "maxLevel": 10
+      "maxLevel": 10,
+      "elevationType": "plains",
+      "vegetationType": "farmland",
+      "climateType": "temperate",
+      "terrainFeatures": ["rivers", "farmlands"],
+      "tag": "low",
+      "levelZone": 5
     },
     {
       "name": "Verdancia",
       "description": "Ancient forestland filled with fae ruins and druidic culture.",
       "deity": "Myrielle",
       "minLevel": 1,
-      "maxLevel": 10
+      "maxLevel": 10,
+      "elevationType": "forest",
+      "vegetationType": "dense",
+      "climateType": "humid",
+      "terrainFeatures": ["ancient trees", "fae ruins"],
+      "tag": "low",
+      "levelZone": 5
     },
     {
       "name": "Durndara",
       "description": "Mountainous realm of dwarven forges and volcanic terrain.",
       "deity": "Durak Thorne",
       "minLevel": 10,
-      "maxLevel": 20
+      "maxLevel": 20,
+      "elevationType": "mountains",
+      "vegetationType": "sparse",
+      "climateType": "cold",
+      "terrainFeatures": ["volcano", "caves"],
+      "tag": "mid",
+      "levelZone": 15
     },
     {
       "name": "Selenora",
       "description": "Moonlit mystic region with floating forests and astral temples.",
       "deity": "Velalune",
       "minLevel": 10,
-      "maxLevel": 20
+      "maxLevel": 20,
+      "elevationType": "floating",
+      "vegetationType": "mystic",
+      "climateType": "cool",
+      "terrainFeatures": ["moon temples", "astral trees"],
+      "tag": "mid",
+      "levelZone": 15
     },
     {
       "name": "Tharnor",
       "description": "War-torn deserts and necrotic battlefields swept by sandstorms.",
       "deity": "Vakhor",
       "minLevel": 20,
-      "maxLevel": 30
+      "maxLevel": 30,
+      "elevationType": "desert",
+      "vegetationType": "barren",
+      "climateType": "arid",
+      "terrainFeatures": ["sandstorm", "ruins"],
+      "tag": "high",
+      "levelZone": 25
     },
     {
       "name": "Vokaria",
       "description": "Ocean-drowned ruins ruled by storm altars and serpent clans.",
       "deity": "Thal’shara",
       "minLevel": 20,
-      "maxLevel": 30
+      "maxLevel": 30,
+      "elevationType": "coastal",
+      "vegetationType": "marsh",
+      "climateType": "tropical",
+      "terrainFeatures": ["flooded ruins", "storm altars"],
+      "tag": "high",
+      "levelZone": 25
     }
   ]
 }


### PR DESCRIPTION
## Summary
- extend RegionData with biome and difficulty metadata
- flesh out EnvironmentSeeder for prefab placement
- add RegionTerrainManager that builds terrain from RegionData
- add BiomeCreatureSpawner for region-based monster spawning
- update `regions.json` with example biome data

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68575342365c83308523b55f554e21c0