### PR TITLE
Implement dialogue & zone managers

### DIFF
--- a/Assets/StreamingAssets/dialogue.json
+++ b/Assets/StreamingAssets/dialogue.json
@@ -24,4 +24,35 @@
       }
     }
   ]
+  ,
+  "dialogueTrees": [
+    {
+      "id": "npc_rootseer_intro",
+      "speaker": "Elder Treovar",
+      "lines": [
+        {
+          "text": "The grove trembles, young one. Will you aid us?",
+          "choices": [
+            { "text": "Yes, what must be done?", "next": "quest_offer_thornroot" },
+            { "text": "Not now.", "next": "end" }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "quest_offer_thornroot",
+      "speaker": "Elder Treovar",
+      "lines": [
+        { "text": "Hunt the Thornhoppers, cleanse their presence. Return when it is done." }
+      ],
+      "quest": "quest_thornroot_001"
+    },
+    {
+      "id": "rootmage_intro",
+      "speaker": "Rootmage Selene",
+      "lines": [
+        { "text": "You have proven yourself, verdant one. The depths welcome you." }
+      ]
+    }
+  ]
 }

--- a/Assets/StreamingAssets/reputation.json
+++ b/Assets/StreamingAssets/reputation.json
@@ -1,3 +1,3 @@
 {
-  "Verdancia": 10
+  "Verdancia": 0
 }

--- a/Assets/StreamingAssets/zones.json
+++ b/Assets/StreamingAssets/zones.json
@@ -13,6 +13,15 @@
       "enemies": [],
       "quests": [],
       "connected_zones": ["Thornroot Paths"]
+    },
+    {
+      "name": "Rootmaze Depths",
+      "levelRange": [2, 4],
+      "enemies": ["Sporeling"],
+      "quests": [],
+      "connected_zones": ["Thornroot Paths"],
+      "unlockReputation": { "Verdancia": 10 },
+      "flavor": "Twisting roots surround you, echoing with ancient whispers."
     }
   ]
 }

--- a/ZoneManager.js
+++ b/ZoneManager.js
@@ -1,0 +1,43 @@
+const fs = require('fs');
+
+class ZoneManager {
+  constructor(jsonPath, state) {
+    const raw = JSON.parse(fs.readFileSync(jsonPath, 'utf8'));
+    this.zones = {};
+    for (const z of raw.zones) {
+      this.zones[z.name] = z;
+    }
+    this.state = state;
+    if (!this.state.unlockedZones) {
+      this.state.unlockedZones = [state.location || 'Thornroot Paths'];
+    }
+  }
+
+  _checkReputation(req = {}) {
+    if (!req) return true;
+    for (const [fac, val] of Object.entries(req)) {
+      if ((this.state.reputation[fac] || 0) < val) return false;
+    }
+    return true;
+  }
+
+  canEnter(name) {
+    const z = this.zones[name];
+    if (!z) return false;
+    if (z.levelRange && this.state.level < z.levelRange[0]) return false;
+    if (z.unlockQuest && !this.state.completedQuests.includes(z.unlockQuest)) return false;
+    if (!this._checkReputation(z.unlockReputation)) return false;
+    return true;
+  }
+
+  travelTo(name) {
+    if (!this.canEnter(name)) return false;
+    this.state.location = name;
+    if (!this.state.unlockedZones.includes(name)) this.state.unlockedZones.push(name);
+    const z = this.zones[name];
+    if (z.flavor) console.log(z.flavor);
+    return true;
+  }
+}
+
+module.exports = ZoneManager;

--- a/dialogueManager.js
+++ b/dialogueManager.js
@@ -1,0 +1,40 @@
+const fs = require('fs');
+
+class DialogueManager {
+  constructor(jsonPath, state) {
+    const raw = JSON.parse(fs.readFileSync(jsonPath, 'utf8'));
+    const trees = raw.dialogueTrees || raw;
+    this.trees = {};
+    for (const t of trees) {
+      this.trees[t.id] = t;
+    }
+    this.state = state;
+  }
+
+  _checkRequirements(req = {}) {
+    if (req.reputation) {
+      for (const [faction, val] of Object.entries(req.reputation)) {
+        if ((this.state.reputation[faction] || 0) < val) {
+          return false;
+        }
+      }
+    }
+    if (req.completedQuest) {
+      if (!this.state.completedQuests.includes(req.completedQuest)) return false;
+    }
+    return true;
+  }
+
+  getLine(id) {
+    const tree = this.trees[id];
+    if (!tree) return null;
+    for (const line of tree.lines) {
+      if (this._checkRequirements(line.requirements)) {
+        return { ...line, speaker: tree.speaker, quest: tree.quest };
+      }
+    }
+    return null;
+  }
+}
+
+module.exports = DialogueManager;

--- a/npcs.json
+++ b/npcs.json
@@ -1,0 +1,16 @@
+[
+  {
+    "id": "elder_treovar",
+    "name": "Elder Treovar",
+    "location": "Thornroot Paths",
+    "dialogueRoot": "npc_rootseer_intro",
+    "reputationRequirement": { "Verdancia": 0 }
+  },
+  {
+    "id": "rootmage_selene",
+    "name": "Rootmage Selene",
+    "location": "Rootmaze Depths",
+    "dialogueRoot": "rootmage_intro",
+    "reputationRequirement": { "Verdancia": 10 }
+  }
+]


### PR DESCRIPTION
## Summary
- add JSON-driven dialogue trees for NPCs
- create dialogue and zone managers in JavaScript
- add NPC configuration with reputation requirements
- extend zones with Rootmaze Depths and gating
- reset Verdancia reputation to zero

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `node -e "const DM=require('./dialogueManager');const d=new DM('Assets/StreamingAssets/dialogue.json',{reputation:{Verdancia:0},completedQuests:[]});console.log(d.getLine('npc_rootseer_intro'));"`
- `node -e "const Z=require('./ZoneManager');const z=new Z('Assets/StreamingAssets/zones.json',{level:2,reputation:{Verdancia:10},completedQuests:[],location:'Thornroot Paths'});console.log(z.canEnter('Rootmaze Depths'));"`

------
https://chatgpt.com/codex/tasks/task_e_68578548f1208330bd4e4798ab970e74