### PR TITLE
Add crafting and forging system

### DIFF
--- a/Assets/StreamingAssets/inventory.json
+++ b/Assets/StreamingAssets/inventory.json
@@ -1,4 +1,6 @@
 {
   "gold": 0,
-  "items": []
+  "materials": {},
+  "consumables": [],
+  "craftedItems": []
 }

--- a/Assets/StreamingAssets/playerState.json
+++ b/Assets/StreamingAssets/playerState.json
@@ -31,5 +31,7 @@
   "ownedMounts": [],
   "activeMount": null,
   "unlockedPerks": [],
-  "boonUses": {}
+  "boonUses": {},
+  "craftingXP": 0,
+  "craftingLevel": 1
 }

--- a/Assets/StreamingAssets/potionRecipes.json
+++ b/Assets/StreamingAssets/potionRecipes.json
@@ -1,0 +1,10 @@
+[
+  {
+    "id": "stormsight",
+    "name": "Draught of Stormsight",
+    "ingredients": ["stormpetal", "skyroot", "flashwater"],
+    "effect": "Reveal hidden enemies and gain lightning resistance",
+    "duration": 3,
+    "type": "consumable"
+  }
+]

--- a/Assets/StreamingAssets/recipes.json
+++ b/Assets/StreamingAssets/recipes.json
@@ -1,9 +1,35 @@
-{
-  "recipes": [
-    {
-      "name": "Healing Salve",
-      "materials": {"Spore Dust": 2, "Herb": 1},
-      "result": {"item": "Healing Salve", "quantity": 1}
-    }
-  ]
-}
+[
+  {
+    "id": "sunsteel_blade",
+    "name": "Sunsteel Blade",
+    "type": "weapon",
+    "requiredMaterials": {
+      "sunsteel_ingot": 3,
+      "leather_grip": 1,
+      "ember_crystal": 1
+    },
+    "requiredCraftingLevel": 5,
+    "requiresStation": "anvil",
+    "effects": {
+      "attackBoost": 12,
+      "fireDamage": 6
+    },
+    "region": "Aurelia",
+    "rarity": "rare"
+  }
+,
+  {
+    "id": "godbane",
+    "name": "Godbane",
+    "type": "weapon",
+    "requiredMaterials": {"soulstone": 2, "godbone": 1},
+    "requiredCraftingLevel": 20,
+    "requiresStation": "legendary_forge",
+    "effects": {"attackBoost": 50, "divineDamage": 20},
+    "region": "Elystren",
+    "rarity": "legendary",
+    "requiredRelic": "divine_spark",
+    "faction": "Elystren Order",
+    "repRequired": 50
+  }
+]

--- a/CraftingManager.js
+++ b/CraftingManager.js
@@ -1,0 +1,102 @@
+const fs = require('fs');
+
+class CraftingManager {
+  constructor(recipesPath, potionsPath, inventoryPath, playerStatePath) {
+    this.recipesPath = recipesPath;
+    this.potionsPath = potionsPath;
+    this.inventoryPath = inventoryPath;
+    this.playerStatePath = playerStatePath;
+    this._loadData();
+  }
+
+  _loadData() {
+    this.recipes = {};
+    if (fs.existsSync(this.recipesPath)) {
+      const data = JSON.parse(fs.readFileSync(this.recipesPath, 'utf8'));
+      for (const r of data) {
+        this.recipes[r.id] = r;
+      }
+    }
+    this.potionRecipes = {};
+    if (fs.existsSync(this.potionsPath)) {
+      const data = JSON.parse(fs.readFileSync(this.potionsPath, 'utf8'));
+      for (const p of data) {
+        this.potionRecipes[p.id] = p;
+      }
+    }
+    this.inventory = fs.existsSync(this.inventoryPath)
+      ? JSON.parse(fs.readFileSync(this.inventoryPath, 'utf8'))
+      : { gold: 0, materials: {}, consumables: [], craftedItems: [] };
+    this.playerState = fs.existsSync(this.playerStatePath)
+      ? JSON.parse(fs.readFileSync(this.playerStatePath, 'utf8'))
+      : { craftingXP: 0, craftingLevel: 1 };
+  }
+
+  _saveInventory() {
+    fs.writeFileSync(this.inventoryPath, JSON.stringify(this.inventory, null, 2));
+  }
+
+  _savePlayerState() {
+    fs.writeFileSync(this.playerStatePath, JSON.stringify(this.playerState, null, 2));
+  }
+
+  listAvailableRecipes() {
+    const list = [];
+    for (const r of Object.values(this.recipes)) {
+      if (this.playerState.craftingLevel >= r.requiredCraftingLevel) {
+        list.push(r);
+      }
+    }
+    return list;
+  }
+
+  _hasMaterials(req) {
+    for (const [mat, count] of Object.entries(req)) {
+      if ((this.inventory.materials[mat] || 0) < count) return false;
+    }
+    return true;
+  }
+
+  _consumeMaterials(req) {
+    for (const [mat, count] of Object.entries(req)) {
+      this.inventory.materials[mat] -= count;
+      if (this.inventory.materials[mat] <= 0) delete this.inventory.materials[mat];
+    }
+  }
+
+  craftItem(id, opts = {}) {
+    const recipe = this.recipes[id];
+    if (!recipe) return false;
+    if (this.playerState.craftingLevel < recipe.requiredCraftingLevel) return false;
+    if (recipe.requiresStation && recipe.requiresStation !== opts.station) return false;
+    if (recipe.region && recipe.region !== opts.region) return false;
+    if (!this._hasMaterials(recipe.requiredMaterials)) return false;
+    this._consumeMaterials(recipe.requiredMaterials);
+    const item = { id: recipe.id, name: recipe.name, rarity: recipe.rarity, effects: recipe.effects };
+    // basic crit chance influenced by playerState.critBonus or boons
+    const critChance = this.playerState.critChance || 0;
+    if (Math.random() < critChance) {
+      item.rarity = 'enhanced-' + item.rarity;
+    }
+    this.inventory.craftedItems.push(item);
+    this.playerState.craftingXP = (this.playerState.craftingXP || 0) + recipe.requiredCraftingLevel * 10;
+    this._saveInventory();
+    this._savePlayerState();
+    return item;
+  }
+
+  brewPotion(id) {
+    const rec = this.potionRecipes[id];
+    if (!rec) return false;
+    const req = rec.ingredients.reduce((a, m) => { a[m] = (a[m] || 0) + 1; return a; }, {});
+    if (!this._hasMaterials(req)) return false;
+    this._consumeMaterials(req);
+    this.inventory.consumables.push({ id: rec.id, name: rec.name, effect: rec.effect, duration: rec.duration });
+    this.playerState.craftingXP = (this.playerState.craftingXP || 0) + 5;
+    this._saveInventory();
+    this._savePlayerState();
+    return true;
+  }
+}
+
+module.exports = CraftingManager;

--- a/LegendaryForge.js
+++ b/LegendaryForge.js
@@ -1,0 +1,68 @@
+const fs = require('fs');
+
+class LegendaryForge {
+  constructor(recipesPath, playerStatePath, inventoryPath) {
+    this.recipesPath = recipesPath;
+    this.playerStatePath = playerStatePath;
+    this.inventoryPath = inventoryPath;
+    this._load();
+  }
+
+  _load() {
+    this.recipes = {};
+    if (fs.existsSync(this.recipesPath)) {
+      const data = JSON.parse(fs.readFileSync(this.recipesPath, 'utf8'));
+      for (const r of data) {
+        if (r.rarity === 'legendary') {
+          this.recipes[r.id] = r;
+        }
+      }
+    }
+    this.player = fs.existsSync(this.playerStatePath)
+      ? JSON.parse(fs.readFileSync(this.playerStatePath, 'utf8'))
+      : { craftingXP: 0, craftingLevel: 1 };
+    this.inventory = fs.existsSync(this.inventoryPath)
+      ? JSON.parse(fs.readFileSync(this.inventoryPath, 'utf8'))
+      : { materials: {}, craftedItems: [] };
+  }
+
+  _save() {
+    fs.writeFileSync(this.inventoryPath, JSON.stringify(this.inventory, null, 2));
+    fs.writeFileSync(this.playerStatePath, JSON.stringify(this.player, null, 2));
+  }
+
+  _hasMaterials(req) {
+    for (const [m, c] of Object.entries(req)) {
+      if ((this.inventory.materials[m] || 0) < c) return false;
+    }
+    return true;
+  }
+
+  _consume(req) {
+    for (const [m, c] of Object.entries(req)) {
+      this.inventory.materials[m] -= c;
+      if (this.inventory.materials[m] <= 0) delete this.inventory.materials[m];
+    }
+  }
+
+  forge(id, options = {}) {
+    const rec = this.recipes[id];
+    if (!rec) return false;
+    if (!this._hasMaterials(rec.requiredMaterials)) return false;
+    if (options.relic !== rec.requiredRelic) return false;
+    if ((this.player.reputation?.[rec.faction] || 0) < (rec.repRequired || 0)) return false;
+    this._consume(rec.requiredMaterials);
+    const item = {
+      id: id,
+      name: options.name || rec.name,
+      rarity: 'legendary',
+      effects: rec.effects
+    };
+    this.inventory.craftedItems.push(item);
+    this.player.craftingXP = (this.player.craftingXP || 0) + 50;
+    this._save();
+    return item;
+  }
+}
+
+module.exports = LegendaryForge;


### PR DESCRIPTION
## Summary
- add `CraftingManager.js` for crafting and potion brewing
- add `LegendaryForge.js` for legendary item creation
- add crafting recipes and potion recipes
- extend player save with crafting XP and level
- restructure inventory to track materials, consumables and crafted items

## Testing
- `node -c CraftingManager.js`
- `node -c LegendaryForge.js`
- `node - <<'NODE'
const CraftingManager = require('./CraftingManager');
const cm = new CraftingManager('Assets/StreamingAssets/recipes.json', 'Assets/StreamingAssets/potionRecipes.json', 'Assets/StreamingAssets/inventory.json', 'Assets/StreamingAssets/playerState.json');
console.log('recipes avail', cm.listAvailableRecipes().length);
NODE`
- `node - <<'NODE'
const LegendaryForge = require('./LegendaryForge');
const lf = new LegendaryForge('Assets/StreamingAssets/recipes.json', 'Assets/StreamingAssets/playerState.json', 'Assets/StreamingAssets/inventory.json');
console.log('legendary recipes', Object.keys(lf.recipes));
NODE`


------
https://chatgpt.com/codex/tasks/task_e_68578c9e4df48330afbd7ca4b9bc64c0