### PR TITLE
Add divine trials and dungeon systems

### DIFF
--- a/Assets/StreamingAssets/divineTrials.json
+++ b/Assets/StreamingAssets/divineTrials.json
@@ -1,0 +1,17 @@
+[
+  {
+    "id": "trial_of_thorns",
+    "god": "Myrielle",
+    "location": "Sylvan Spiral",
+    "requirements": {
+      "reputation": { "Verdancia": 30 },
+      "quest": "cleanse_thornroot"
+    },
+    "encounter": ["Sporelord", "Thornshade Warden"],
+    "reward": {
+      "boon": "verdant_resurrection",
+      "legendaryItem": "heartwood_staff",
+      "craftingXP": 250
+    }
+  }
+]

--- a/Assets/StreamingAssets/dungeons.json
+++ b/Assets/StreamingAssets/dungeons.json
@@ -1,0 +1,11 @@
+[
+  {
+    "id": "lantern_sepulcher",
+    "region": "Vokaria",
+    "levelRange": "10–15",
+    "enemyTypes": ["Soulwraith", "Gravecrawler"],
+    "boss": "Warden of the Final Flame",
+    "lootTable": ["soul_ink", "veil_dye", "obsidian_core"],
+    "isRepeatable": true
+  }
+]

--- a/Assets/StreamingAssets/mythicEncounters.json
+++ b/Assets/StreamingAssets/mythicEncounters.json
@@ -1,0 +1,10 @@
+[
+  {
+    "id": "moondrinker_arrival",
+    "trigger": "duringEclipse",
+    "location": "Crescent Hollow",
+    "effect": "memoryWipe",
+    "combat": true,
+    "reward": "moonwoven_crown"
+  }
+]

--- a/Assets/StreamingAssets/playerState.json
+++ b/Assets/StreamingAssets/playerState.json
@@ -33,5 +33,11 @@
   "unlockedPerks": [],
   "boonUses": {},
   "craftingXP": 0,
-  "craftingLevel": 1
+  "craftingLevel": 1,
+  "availableTrials": [],
+  "completedTrials": [],
+  "activeTrial": null,
+  "activeDungeon": null,
+  "dungeonHistory": [],
+  "encounterHistory": []
 }

--- a/DungeonManager.js
+++ b/DungeonManager.js
@@ -1,0 +1,31 @@
+const fs = require('fs');
+
+class DungeonManager {
+  constructor(jsonPath, state) {
+    this.state = state;
+    this.dungeons = {};
+    if (fs.existsSync(jsonPath)) {
+      const data = JSON.parse(fs.readFileSync(jsonPath, 'utf8'));
+      for (const d of data) {
+        this.dungeons[d.id] = d;
+      }
+    }
+  }
+
+  enterDungeon(id) {
+    const d = this.dungeons[id];
+    if (!d) return false;
+    this.state.activeDungeon = id;
+    this.state.dungeonHistory = this.state.dungeonHistory || [];
+    this.state.dungeonHistory.push({ id, timestamp: Date.now() });
+    return true;
+  }
+
+  completeDungeon(id) {
+    if (this.state.activeDungeon !== id) return false;
+    this.state.activeDungeon = null;
+    return true;
+  }
+}
+
+module.exports = DungeonManager;

--- a/EncounterManager.js
+++ b/EncounterManager.js
@@ -1,0 +1,27 @@
+const fs = require('fs');
+
+class EncounterManager {
+  constructor(jsonPath, state) {
+    this.state = state;
+    this.encounters = {};
+    if (fs.existsSync(jsonPath)) {
+      const data = JSON.parse(fs.readFileSync(jsonPath, 'utf8'));
+      for (const e of data) {
+        this.encounters[e.id] = e;
+      }
+    }
+  }
+
+  trigger(eventKey) {
+    const matches = Object.values(this.encounters).filter(e => e.trigger === eventKey);
+    const triggered = [];
+    for (const enc of matches) {
+      this.state.encounterHistory = this.state.encounterHistory || [];
+      this.state.encounterHistory.push({ id: enc.id, time: Date.now() });
+      triggered.push(enc);
+    }
+    return triggered;
+  }
+}
+
+module.exports = EncounterManager;

--- a/TrialManager.js
+++ b/TrialManager.js
@@ -1,0 +1,59 @@
+const fs = require('fs');
+
+class TrialManager {
+  constructor(jsonPath, state) {
+    this.state = state;
+    this.trials = {};
+    if (fs.existsSync(jsonPath)) {
+      const data = JSON.parse(fs.readFileSync(jsonPath, 'utf8'));
+      for (const t of data) {
+        this.trials[t.id] = t;
+      }
+    }
+  }
+
+  _meetsRequirements(trial) {
+    const req = trial.requirements || {};
+    if (req.reputation) {
+      for (const [fac, val] of Object.entries(req.reputation)) {
+        if ((this.state.reputation?.[fac] || 0) < val) return false;
+      }
+    }
+    if (req.quest && !this.state.completedQuests?.includes(req.quest)) return false;
+    return true;
+  }
+
+  startTrial(id) {
+    const t = this.trials[id];
+    if (!t) return false;
+    if (!this._meetsRequirements(t)) return false;
+    this.state.activeTrial = id;
+    return true;
+  }
+
+  completeTrial(id) {
+    const t = this.trials[id];
+    if (!t || this.state.activeTrial !== id) return false;
+    this.state.activeTrial = null;
+    this.state.completedTrials = this.state.completedTrials || [];
+    if (!this.state.completedTrials.includes(id)) {
+      this.state.completedTrials.push(id);
+    }
+    const reward = t.reward || {};
+    if (reward.legendaryItem) {
+      this.state.inventory.items.push(reward.legendaryItem);
+    }
+    if (reward.craftingXP) {
+      this.state.craftingXP = (this.state.craftingXP || 0) + reward.craftingXP;
+    }
+    if (reward.boon) {
+      this.state.activeBoons = this.state.activeBoons || [];
+      if (!this.state.activeBoons.includes(reward.boon)) {
+        this.state.activeBoons.push(reward.boon);
+      }
+    }
+    return true;
+  }
+}
+
+module.exports = TrialManager;

--- a/ZoneManager.js
+++ b/ZoneManager.js
@@ -5,7 +5,12 @@ class ZoneManager {
     const raw = JSON.parse(fs.readFileSync(jsonPath, 'utf8'));
     this.zones = {};
     for (const z of raw.zones) {
-      this.zones[z.name] = z;
+      this.zones[z.name] = {
+        trials: [],
+        dungeons: [],
+        encounters: [],
+        ...z
+      };
     }
     this.state = state;
     if (!this.state.unlockedZones) {

--- a/combatEngine.py
+++ b/combatEngine.py
@@ -43,6 +43,8 @@ class CombatEngine:
     def combat(self, player_data, enemy_data, choose_skill_fn=None):
         player = Combatant(player_data, self.skills_db)
         enemy = Combatant(enemy_data, self.skills_db)
+        phases = enemy_data.get("bossPhases", [])
+        phase_index = 0
         log = []
         turn = 0
         while player.hp > 0 and enemy.hp > 0:
@@ -77,6 +79,14 @@ class CombatEngine:
                 log.append(f"{player.name} attacks for {dmg} dmg")
             if enemy.hp <= 0:
                 break
+            if phase_index < len(phases) and enemy.hp <= phases[phase_index].get("threshold", 0):
+                msg = phases[phase_index].get("dialogue")
+                if msg:
+                    log.append(msg)
+                phase_skill = phases[phase_index].get("addSkill")
+                if phase_skill and phase_skill not in enemy.skills:
+                    enemy.skills.append(phase_skill)
+                phase_index += 1
             # enemy turn (random)
             tick_cooldowns(player)
             tick_cooldowns(enemy)

--- a/questSystem.py
+++ b/questSystem.py
@@ -27,6 +27,7 @@ class QuestManager:
         self.mount_mgr = mount_mgr
         self.boon_mgr = boon_mgr
         self.quests_db = {q['id']: q for q in _load_json('quests.json', [])}
+        self.trials_db = {t['id']: t for t in _load_json('divineTrials.json', [])}
 
     # ---- Quest Acquisition ----
     def accept_quest(self, quest_id):
@@ -70,6 +71,11 @@ class QuestManager:
             self.boon_mgr.activate(boon)
         self.state['completedQuests'].append(quest)
         self.state['activeQuests'].remove(quest)
+        for trial in self.trials_db.values():
+            req = trial.get('requirements', {})
+            if req.get('quest') == quest.get('id'):
+                self.state.setdefault('availableTrials', []).append(trial['id'])
+                print(f"Divine trial unlocked: {trial['id']}")
 
     # ---- Dev Helpers ----
     def quest_log(self):


### PR DESCRIPTION
## Summary
- expand `ZoneManager` to track trials, dungeons and encounters
- implement `TrialManager`, `DungeonManager` and `EncounterManager`
- support boss phases in `combatEngine`
- unlock trials from quest completions
- extend player state with trial/dungeon fields
- add sample data for divine trials, dungeons and mythic encounters

## Testing
- `python -m py_compile questSystem.py combatEngine.py`
- `node -e "require('./TrialManager.js');require('./DungeonManager.js');require('./EncounterManager.js');"`

------
https://chatgpt.com/codex/tasks/task_e_68579007c13883308d05f5c41460be9a