### PR TITLE
Secure OpenAI key loading

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/Assets/Resources/Secrets/openai_config.json

--- a/Assets/Scripts/AICompanion.cs
+++ b/Assets/Scripts/AICompanion.cs
@@ -16,6 +16,16 @@ public class AICompanion : MonoBehaviour
 
     private const int MaxHistory = 10;
     private readonly List<string> history = new List<string>();
+    private string apiKey;
+
+    private void Start()
+    {
+        apiKey = ConfigLoader.LoadOpenAIKey();
+        if (string.IsNullOrEmpty(apiKey))
+        {
+            Debug.LogWarning("OpenAI API key missing; AI features disabled.");
+        }
+    }
 
     /// <summary>
     /// Send player input and context to the OpenAI API.
@@ -27,10 +37,9 @@ public class AICompanion : MonoBehaviour
 
     private IEnumerator QueryOpenAI(string input, string location, string quest)
     {
-        string apiKey = System.Environment.GetEnvironmentVariable("OPENAI_API_KEY");
         if (string.IsNullOrEmpty(apiKey))
         {
-            Debug.LogError("OPENAI_API_KEY not set");
+            Debug.LogError("OpenAI API key not set");
             yield break;
         }
 

--- a/Assets/Scripts/ConfigLoader.cs
+++ b/Assets/Scripts/ConfigLoader.cs
@@ -1,0 +1,27 @@
+using System.IO;
+using UnityEngine;
+
+[System.Serializable]
+public class OpenAIConfig
+{
+    public string apiKey;
+}
+
+public class ConfigLoader : MonoBehaviour
+{
+    public static string LoadOpenAIKey()
+    {
+        string path = Path.Combine(Application.dataPath, "Resources/Secrets/openai_config.json");
+        if (File.Exists(path))
+        {
+            string json = File.ReadAllText(path);
+            OpenAIConfig config = JsonUtility.FromJson<OpenAIConfig>(json);
+            return config.apiKey;
+        }
+        else
+        {
+            Debug.LogError("OpenAI config file not found.");
+            return null;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- load OpenAI keys from `openai_config.json`
- ignore the secrets config file from git
- use the loaded key in `AICompanion`

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68579da5e494833081edf5d218646c0b