### PR TITLE
Add failsafes, help command, AI personalities and time tracking

### DIFF
--- a/Assets/Scripts/AICompanion.cs
+++ b/Assets/Scripts/AICompanion.cs
@@ -11,10 +11,10 @@ public class AICompanion : MonoBehaviour
 {
     public string npcId = "NPC";
     [TextArea]
-    public string systemPrompt = "You are a helpful NPC.";
+    public string systemPrompt = "";
     public DialogueManager dialogueManager;
 
-    private const int MaxHistory = 10;
+    private const int MaxHistory = 12;
     private readonly List<string> history = new List<string>();
     private string apiKey;
 
@@ -39,13 +39,17 @@ public class AICompanion : MonoBehaviour
     {
         if (string.IsNullOrEmpty(apiKey))
         {
+            dialogueManager?.DisplayLine(npcId, "The companion goes silent. Perhaps the veil is too thick today.");
             Debug.LogError("OpenAI API key not set");
             yield break;
         }
 
+        string persona = string.IsNullOrEmpty(systemPrompt)
+            ? "You are a helpful companion NPC in a fantasy world."
+            : systemPrompt;
         var messages = new List<Message>
         {
-            new Message { role = "system", content = systemPrompt }
+            new Message { role = "system", content = persona }
         };
 
         if (!string.IsNullOrEmpty(location) || !string.IsNullOrEmpty(quest))
@@ -82,6 +86,7 @@ public class AICompanion : MonoBehaviour
             if (req.result != UnityWebRequest.Result.Success)
             {
                 Debug.LogError("OpenAI request failed: " + req.error);
+                dialogueManager?.DisplayLine(npcId, "The companion goes silent. Perhaps the veil is too thick today.");
                 yield break;
             }
 
@@ -92,6 +97,10 @@ public class AICompanion : MonoBehaviour
                 history.Add("NPC:" + content);
                 TrimHistory();
                 dialogueManager?.DisplayLine(npcId, content);
+            }
+            else
+            {
+                dialogueManager?.DisplayLine(npcId, "The companion goes silent. Perhaps the veil is too thick today.");
             }
         }
     }

--- a/Assets/Scripts/Characters/NPCManager.cs
+++ b/Assets/Scripts/Characters/NPCManager.cs
@@ -45,7 +45,11 @@ public class NPCManager : MonoBehaviour
 
     public string GetSystemPrompt(string id)
     {
-        return lookup.TryGetValue(id, out var npc) ? npc.systemPrompt : string.Empty;
+        if (lookup.TryGetValue(id, out var npc))
+        {
+            return !string.IsNullOrEmpty(npc.personality) ? npc.personality : npc.systemPrompt;
+        }
+        return string.Empty;
     }
 
     public string GetName(string id)
@@ -63,7 +67,7 @@ public class NPCManager : MonoBehaviour
 
         if (npc.isAI && aiCompanion != null)
         {
-            aiCompanion.systemPrompt = npc.systemPrompt;
+            aiCompanion.systemPrompt = !string.IsNullOrEmpty(npc.personality) ? npc.personality : npc.systemPrompt;
             aiCompanion.npcId = npc.name;
             aiCompanion.dialogueManager = dialogueManager;
             aiCompanion.HandlePlayerInput(playerInput, location, quest);
@@ -84,6 +88,8 @@ public class NPCManager : MonoBehaviour
         public bool isAI;
         [TextArea]
         public string systemPrompt;
+        [TextArea]
+        public string personality;
     }
 
     [System.Serializable]

--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -25,6 +25,19 @@ public class GameManager : MonoBehaviour
     {
         // Load JSON data from Resources/Data using JsonLoader
         playerState = JsonLoader.LoadJson<PlayerState>("playerState.json");
+        if (playerState == null)
+        {
+            playerState = new PlayerState
+            {
+                level = 1,
+                xp = 0,
+                hp = 25,
+                zone = "Thornroot Paths",
+                inventory = new string[] { "Cleanse the Grove" }
+            };
+            logManager?.Log("New character created.");
+            Debug.Log("New character created.");
+        }
         skillDb = JsonLoader.LoadJson<SkillDatabase>("skills.json");
         questDb = JsonLoader.LoadJson<QuestDatabase>("quests.json");
         dialogueDb = JsonLoader.LoadJson<DialogueDatabase>("dialogue.json");

--- a/Assets/Scripts/InputHandler.cs
+++ b/Assets/Scripts/InputHandler.cs
@@ -70,6 +70,21 @@ public class InputHandler : MonoBehaviour
         {
             gameManager.zoneManager?.ShowStats();
         }
+        else if (command == "help" || command == "commands" || command == "?")
+        {
+            string helpText =
+                "Available Commands:\n" +
+                "- talkTo(\"NPC\")\n" +
+                "- travelTo(\"Zone\")\n" +
+                "- attack(\"Enemy\")\n" +
+                "- useSkill(\"SkillName\")\n" +
+                "- useItem(\"ItemName\")\n" +
+                "- openInventory()\n" +
+                "- openQuests()\n" +
+                "- showStats()\n" +
+                "- help()";
+            gameManager.logManager?.Log(helpText);
+        }
 
         uiManager?.UpdateHUD(gameManager.playerState);
     }

--- a/Assets/Scripts/TimeManager.cs
+++ b/Assets/Scripts/TimeManager.cs
@@ -1,0 +1,58 @@
+using UnityEngine;
+
+/// <summary>
+/// Tracks in-game time for future timed events or narrative triggers.
+/// </summary>
+public class TimeManager : MonoBehaviour
+{
+    public int daysPassed;
+    public int hours;
+    public int minutes;
+
+    /// <summary>
+    /// Advance time for traveling between zones (+6 hours).
+    /// </summary>
+    public void AdvanceTravel()
+    {
+        AddMinutes(6 * 60);
+    }
+
+    /// <summary>
+    /// Advance time for resting (+8 hours).
+    /// </summary>
+    public void AdvanceRest()
+    {
+        AddMinutes(8 * 60);
+    }
+
+    /// <summary>
+    /// Advance time when clearing a dungeon (+12 hours).
+    /// </summary>
+    public void AdvanceDungeonClear()
+    {
+        AddMinutes(12 * 60);
+    }
+
+    private void AddMinutes(int mins)
+    {
+        minutes += mins;
+        while (minutes >= 60)
+        {
+            minutes -= 60;
+            hours++;
+        }
+        while (hours >= 24)
+        {
+            hours -= 24;
+            daysPassed++;
+        }
+    }
+
+    /// <summary>
+    /// Returns the current in-game time formatted as a string.
+    /// </summary>
+    public string GetCurrentTime()
+    {
+        return $"Day {daysPassed}, {hours:D2}:{minutes:D2}";
+    }
+}

--- a/Assets/StreamingAssets/npcs.json
+++ b/Assets/StreamingAssets/npcs.json
@@ -25,7 +25,8 @@
       "dialogueRoot": "",
       "reputationRequirement": {},
       "isAI": true,
-      "systemPrompt": "You are a mystic companion named Lysara, who offers cryptic guidance and poetic insight."
+      "systemPrompt": "",
+      "personality": "You are Lysara, a Moonveil priestess. You speak in riddles and dreams. You remember the player from a forgotten past."
     }
   ]
 }

--- a/npcs.json
+++ b/npcs.json
@@ -12,5 +12,14 @@
     "location": "Rootmaze Depths",
     "dialogueRoot": "rootmage_intro",
     "reputationRequirement": { "Verdancia": 10 }
+  },
+  {
+    "id": "lysara",
+    "name": "Lysara",
+    "location": "Dreamer's Nook",
+    "dialogueRoot": "",
+    "reputationRequirement": {},
+    "isAI": true,
+    "personality": "You are Lysara, a Moonveil priestess. You speak in riddles and dreams. You remember the player from a forgotten past."
   }
 ]


### PR DESCRIPTION
## Summary
- default character created if player save is missing
- add AI companion fallback phrases and personality support
- provide help command with available commands
- extend NPC data with personality property
- implement simple TimeManager for internal game time

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68579f07ad848330861632626e609475